### PR TITLE
feat: add the feature flag `experimental_primaryModule.sheet.preview` for an experimental component

### DIFF
--- a/src/app-entry.tsx
+++ b/src/app-entry.tsx
@@ -74,7 +74,7 @@ export default function App() {
           <ReactQueryDevtools
             initialIsOpen={false}
             position="bottom"
-            buttonPosition="bottom-left"
+            buttonPosition="top-left"
           />
           <TailwindScreenDevTool />
         </AuthProvider>

--- a/src/components/header/app-navigation.tsx
+++ b/src/components/header/app-navigation.tsx
@@ -95,6 +95,7 @@ export const AppNavigation = (props: Props) => {
         to: "/agreements",
         search: (current) => ({
           ...current,
+          agreement_id: undefined,
           page: 1,
           size: tableRowCount,
           filters: undefined,

--- a/src/components/primary-module/preview-sheet.tsx
+++ b/src/components/primary-module/preview-sheet.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+
+import { cn } from "@/utils";
+
+export interface PrimaryModulePreviewSheetProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: React.ReactNode;
+  className?: string;
+  headerComponent?: () => JSX.Element;
+}
+
+export function PrimaryModulePreviewSheet(
+  props: PrimaryModulePreviewSheetProps
+) {
+  const {
+    open,
+    onOpenChange,
+    children,
+    className,
+    headerComponent: Header,
+  } = props;
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className={cn(
+          "bottom-2 right-2 top-2 h-auto w-5/6 rounded-lg border bg-card shadow-xl sm:bottom-2.5 sm:right-2.5 sm:top-2.5 sm:max-w-lg",
+          className
+        )}
+        noBackdrop
+      >
+        {Header && <Header />}
+        {children}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -39,6 +39,7 @@ import {
   MoonIcon,
   MoreVerticalIcon,
   MoveDownLeftIcon,
+  MoveUpRightIcon,
   PencilIcon,
   PlayIcon,
   PlusCircleIcon,
@@ -123,4 +124,5 @@ export const icons = {
   Sheet: SheetIcon,
   User: User2Icon,
   Users: Users2Icon,
+  GoTo: MoveUpRightIcon,
 } as const;

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+interface SheetOverlayCustomProps {
+  noBackdrop?: boolean;
+}
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay> & SheetOverlayCustomProps,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> &
+    SheetOverlayCustomProps
+>(({ className, noBackdrop = false, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      !noBackdrop ? "bg-black/80 " : "",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -25,7 +25,7 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      !noBackdrop ? "bg-black/80 " : "",
+      !noBackdrop ? "bg-black/80 " : "bg-black/10",
       className
     )}
     {...props}
@@ -55,27 +55,34 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  noBackdrop?: boolean;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
+>(
+  (
+    { side = "right", className, children, noBackdrop = false, ...props },
+    ref
+  ) => (
+    <SheetPortal>
+      <SheetOverlay noBackdrop={noBackdrop} />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+);
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -30,7 +30,7 @@ function RootComponent() {
     <React.Fragment>
       <Outlet />
       <FeatureTogglesDialog />
-      <RouterDevTools position="top-right" />
+      <RouterDevTools position="bottom-left" />
     </React.Fragment>
   );
 }

--- a/src/routes/_auth/agreements/-components/preview-agreement-sheet.tsx
+++ b/src/routes/_auth/agreements/-components/preview-agreement-sheet.tsx
@@ -30,7 +30,7 @@ interface PreviewAgreementSheetProps extends Auth {
   onOpenChange: PrimaryModulePreviewSheetProps["onOpenChange"];
 }
 
-export function PreviewAgreementSheet(props: PreviewAgreementSheetProps) {
+function PreviewAgreementSheet(props: PreviewAgreementSheetProps) {
   const { open, onOpenChange } = props;
 
   return (
@@ -40,6 +40,7 @@ export function PreviewAgreementSheet(props: PreviewAgreementSheetProps) {
     </PrimaryModulePreviewSheet>
   );
 }
+export default PreviewAgreementSheet;
 
 function AgreementLinks(props: {
   agreementId: string | undefined;

--- a/src/routes/_auth/agreements/-components/preview-agreement-sheet.tsx
+++ b/src/routes/_auth/agreements/-components/preview-agreement-sheet.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { format } from "date-fns";
+
+import {
+  PrimaryModulePreviewSheet,
+  PrimaryModulePreviewSheetProps,
+} from "@/components/primary-module/preview-sheet";
+import { buttonVariants } from "@/components/ui/button";
+import { icons } from "@/components/ui/icons";
+import { Separator } from "@/components/ui/separator";
+import {
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { useDatePreference } from "@/hooks/useDatePreferences";
+
+import { fetchAgreementByIdOptions } from "@/utils/query/agreement";
+import type { Auth } from "@/utils/query/helpers";
+
+import { cn } from "@/utils";
+
+interface PreviewAgreementSheetProps extends Auth {
+  agreementId: string | undefined;
+  open: PrimaryModulePreviewSheetProps["open"];
+  onOpenChange: PrimaryModulePreviewSheetProps["onOpenChange"];
+}
+
+export function PreviewAgreementSheet(props: PreviewAgreementSheetProps) {
+  const { open, onOpenChange } = props;
+
+  return (
+    <PrimaryModulePreviewSheet open={open} onOpenChange={onOpenChange}>
+      {/* <AgreementSheetSkeleton agreementId={props.agreementId} /> */}
+      <AgreementSheetContent {...props} />
+    </PrimaryModulePreviewSheet>
+  );
+}
+
+function AgreementLinks(props: {
+  agreementId: string | undefined;
+  isCheckedIn?: boolean;
+}) {
+  const { agreementId = "0", isCheckedIn = false } = props;
+  return (
+    <div className="absolute left-4 top-4 flex gap-4 pl-2">
+      <Link
+        to="/agreements/$agreementId"
+        params={{ agreementId: String(agreementId) }}
+        className={cn(
+          buttonVariants({ variant: "link", size: "sm" }),
+          "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+        )}
+      >
+        <icons.GoTo className="h-3.5 w-3.5" />
+        <span>View</span>
+      </Link>
+      {!isCheckedIn && (
+        <Link
+          to="/agreements/$agreementId/check-in"
+          search={() => ({ stage: "rental-information" })}
+          params={{ agreementId: String(agreementId) }}
+          className={cn(
+            buttonVariants({ variant: "link", size: "sm" }),
+            "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+          )}
+        >
+          <icons.Checkin className="h-3.5 w-3.5" />
+          <span className="inline-block">Checkin</span>
+        </Link>
+      )}
+      {isCheckedIn ? (
+        <Link
+          to="/agreements/$agreementId/check-in"
+          search={() => ({ stage: "rental-information" })}
+          params={{ agreementId: String(agreementId) }}
+          className={cn(
+            buttonVariants({ variant: "link", size: "sm" }),
+            "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+          )}
+        >
+          <icons.Edit className="h-3.5 w-3.5" />
+          <span className="inline-block">Edit</span>
+        </Link>
+      ) : (
+        <Link
+          to="/agreements/$agreementId/edit"
+          search={() => ({ stage: "rental-information" })}
+          params={{ agreementId: String(agreementId) }}
+          className={cn(
+            buttonVariants({ variant: "link", size: "sm" }),
+            "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+          )}
+        >
+          <icons.Edit className="h-3.5 w-3.5" />
+          <span className="inline-block">Edit</span>
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function AgreementSheetSkeleton(props: { agreementId: string | undefined }) {
+  return (
+    <>
+      <AgreementLinks agreementId={props.agreementId} isCheckedIn />
+      <SheetHeader className="mt-8 text-start">
+        <SheetTitle className="">
+          <Skeleton className="h-9 w-60" />
+          <span className="sr-only">Loading....</span>
+        </SheetTitle>
+        <SheetDescription asChild>
+          <Skeleton className="h-6 w-3/4" />
+        </SheetDescription>
+      </SheetHeader>
+      <div className="mt-4 flex flex-col space-y-2">
+        <Separator />
+      </div>
+    </>
+  );
+}
+
+interface AgreementSheetContentProps extends PreviewAgreementSheetProps {}
+
+function AgreementSheetContent(props: AgreementSheetContentProps) {
+  const { agreementId, auth } = props;
+
+  const agreementOptions = React.useMemo(
+    () => fetchAgreementByIdOptions({ auth, agreementId: agreementId ?? "0" }),
+    [agreementId, auth]
+  );
+
+  const { dateTimeFormat } = useDatePreference();
+
+  const query = useQuery(agreementOptions);
+
+  const data =
+    query.status === "success" && query.data.status === 200
+      ? query.data.body
+      : null;
+
+  if (!data) {
+    return <AgreementSheetSkeleton agreementId={agreementId} />;
+  }
+
+  const isCheckedIn = data?.returnDate ? true : false;
+
+  return (
+    <>
+      <AgreementLinks agreementId={agreementId} isCheckedIn={isCheckedIn} />
+      <div className="absolute left-4 top-4 flex gap-4 pl-2">
+        <Link
+          to="/agreements/$agreementId"
+          params={{ agreementId: String(agreementId) }}
+          className={cn(
+            buttonVariants({ variant: "link", size: "sm" }),
+            "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+          )}
+        >
+          <icons.GoTo className="h-3.5 w-3.5" />
+          <span>View</span>
+        </Link>
+        {!isCheckedIn && (
+          <Link
+            to="/agreements/$agreementId/check-in"
+            search={() => ({ stage: "rental-information" })}
+            params={{ agreementId: String(agreementId) }}
+            className={cn(
+              buttonVariants({ variant: "link", size: "sm" }),
+              "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+            )}
+          >
+            <icons.Checkin className="h-3.5 w-3.5" />
+            <span className="inline-block">Checkin</span>
+          </Link>
+        )}
+        {isCheckedIn ? (
+          <Link
+            to="/agreements/$agreementId/check-in"
+            search={() => ({ stage: "rental-information" })}
+            params={{ agreementId: String(agreementId) }}
+            className={cn(
+              buttonVariants({ variant: "link", size: "sm" }),
+              "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+            )}
+          >
+            <icons.Edit className="h-3.5 w-3.5" />
+            <span className="inline-block">Edit</span>
+          </Link>
+        ) : (
+          <Link
+            to="/agreements/$agreementId/edit"
+            search={() => ({ stage: "rental-information" })}
+            params={{ agreementId: String(agreementId) }}
+            className={cn(
+              buttonVariants({ variant: "link", size: "sm" }),
+              "h-4 gap-1 p-0 text-sm opacity-75 hover:opacity-100"
+            )}
+          >
+            <icons.Edit className="h-3.5 w-3.5" />
+            <span className="inline-block">Edit</span>
+          </Link>
+        )}
+      </div>
+      <SheetHeader className="mt-8 text-start">
+        <SheetTitle className="h-9 text-3xl">{data.agreementNumber}</SheetTitle>
+        <SheetDescription className="h-6">
+          <span>
+            {data.createdDate &&
+              `Created on ${format(data.createdDate, dateTimeFormat)}`}
+          </span>
+          <span className="hidden sm:inline-block">
+            {data.createdDate && data.createdByName && <>&nbsp;</>}
+            {data.createdByName && `by ${data.createdByName}`}
+          </span>
+        </SheetDescription>
+      </SheetHeader>
+      <div className="mt-4 flex flex-col space-y-2">
+        <Separator />
+      </div>
+    </>
+  );
+}

--- a/src/routes/_auth/agreements/index.route.lazy.tsx
+++ b/src/routes/_auth/agreements/index.route.lazy.tsx
@@ -174,7 +174,7 @@ function AgreementsSearchPage() {
                       search={() => ({ tab: "summary" })}
                       className={cn(
                         buttonVariants({ variant: "link" }),
-                        "group p-0"
+                        "group px-2 py-2"
                       )}
                     >
                       <icons.GoTo className="h-4 w-4 border-b-2 border-transparent group-hover:border-primary" />

--- a/src/routes/_auth/agreements/index.route.lazy.tsx
+++ b/src/routes/_auth/agreements/index.route.lazy.tsx
@@ -22,14 +22,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { icons } from "@/components/ui/icons";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
 
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -51,6 +43,8 @@ import { fetchVehiclesTypesOptions } from "@/utils/query/vehicle";
 import { titleMaker } from "@/utils/title-maker";
 
 import { cn, getXPaginationFromHeaders } from "@/utils";
+
+import { PreviewAgreementSheet } from "./-components/preview-agreement-sheet";
 
 export const Route = createLazyFileRoute("/_auth/agreements/")({
   component: AgreementsSearchPage,
@@ -286,17 +280,12 @@ function AgreementsSearchPage() {
 
   return (
     <>
-      <Sheet open={!!previewAgreementId} onOpenChange={handleClosePreview}>
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle>Are you absolutely sure?</SheetTitle>
-            <SheetDescription>
-              This action cannot be undone. This will permanently delete your
-              account and remove your data from our servers.
-            </SheetDescription>
-          </SheetHeader>
-        </SheetContent>
-      </Sheet>
+      <PreviewAgreementSheet
+        agreementId={previewAgreementId}
+        open={!!previewAgreementId}
+        onOpenChange={handleClosePreview}
+        auth={authParams}
+      />
 
       <section
         className={cn(
@@ -312,19 +301,6 @@ function AgreementsSearchPage() {
             <h1 className="text-2xl font-semibold leading-6">Agreements</h1>
           </div>
           <div className="flex w-full gap-2 sm:w-max">
-            {previewModuleSheet && (
-              <Link
-                to="/agreements"
-                search={(prev) => ({
-                  ...prev,
-                  agreement_id: "167661",
-                })}
-                className={cn(buttonVariants({ size: "sm" }), "w-max")}
-              >
-                <icons.Plus className="h-4 w-4 sm:mr-2" />
-                <span>Trigger preview agreement</span>
-              </Link>
-            )}
             <Link
               to="/agreements/new"
               search={() => ({ stage: "rental-information" })}

--- a/src/routes/_auth/agreements/index.route.lazy.tsx
+++ b/src/routes/_auth/agreements/index.route.lazy.tsx
@@ -25,6 +25,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { icons } from "@/components/ui/icons";
 
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { saveColumnSettings } from "@/api/save-column-settings";
 
 import type { TAgreementListItemParsed } from "@/schemas/agreement";
@@ -33,6 +34,7 @@ import {
   AgreementDateTimeColumns,
   sortColOrderByOrderIndex,
 } from "@/utils/columns";
+import { incompletePrimaryModuleSheetPreviewFeatureFlag } from "@/utils/features";
 import {
   fetchAgreementStatusesOptions,
   fetchAgreementTypesOptions,
@@ -63,6 +65,11 @@ function AgreementsSearchPage() {
     queryClient,
   } = routeApi.useRouteContext();
   const { searchFilters, pageNumber, size } = search;
+
+  const [previewModuleSheet] = useLocalStorage(
+    incompletePrimaryModuleSheetPreviewFeatureFlag.id,
+    incompletePrimaryModuleSheetPreviewFeatureFlag.default_value
+  );
 
   const [_trackTableLoading, _setTrackTableLoading] = useState(false);
 
@@ -251,6 +258,19 @@ function AgreementsSearchPage() {
             <h1 className="text-2xl font-semibold leading-6">Agreements</h1>
           </div>
           <div className="flex w-full gap-2 sm:w-max">
+            {previewModuleSheet && (
+              <Link
+                to="/agreements"
+                search={(prev) => ({
+                  ...prev,
+                  agreement_id: "167661",
+                })}
+                className={cn(buttonVariants({ size: "sm" }), "w-max")}
+              >
+                <icons.Plus className="h-4 w-4 sm:mr-2" />
+                <span>Trigger preview agreement</span>
+              </Link>
+            )}
             <Link
               to="/agreements/new"
               search={() => ({ stage: "rental-information" })}

--- a/src/routes/_auth/agreements/index.route.lazy.tsx
+++ b/src/routes/_auth/agreements/index.route.lazy.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
   createLazyFileRoute,
@@ -44,11 +44,13 @@ import { titleMaker } from "@/utils/title-maker";
 
 import { cn, getXPaginationFromHeaders } from "@/utils";
 
-import { PreviewAgreementSheet } from "./-components/preview-agreement-sheet";
-
 export const Route = createLazyFileRoute("/_auth/agreements/")({
   component: AgreementsSearchPage,
 });
+
+const PreviewAgreementSheet = React.lazy(
+  () => import("./-components/preview-agreement-sheet")
+);
 
 const columnHelper = createColumnHelper<TAgreementListItemParsed>();
 
@@ -280,12 +282,16 @@ function AgreementsSearchPage() {
 
   return (
     <>
-      <PreviewAgreementSheet
-        agreementId={previewAgreementId}
-        open={!!previewAgreementId}
-        onOpenChange={handleClosePreview}
-        auth={authParams}
-      />
+      <React.Suspense fallback={null}>
+        {previewModuleSheet ? (
+          <PreviewAgreementSheet
+            agreementId={previewAgreementId}
+            open={!!previewAgreementId}
+            onOpenChange={handleClosePreview}
+            auth={authParams}
+          />
+        ) : null}
+      </React.Suspense>
 
       <section
         className={cn(

--- a/src/routes/_auth/agreements/index.route.lazy.tsx
+++ b/src/routes/_auth/agreements/index.route.lazy.tsx
@@ -33,7 +33,7 @@ import {
   AgreementDateTimeColumns,
   sortColOrderByOrderIndex,
 } from "@/utils/columns";
-import { incompletePrimaryModuleSheetPreviewFeatureFlag } from "@/utils/features";
+import { experimentalPrimaryModuleSheetPreviewFeatureFlag } from "@/utils/features";
 import {
   fetchAgreementStatusesOptions,
   fetchAgreementTypesOptions,
@@ -82,9 +82,9 @@ function AgreementsSearchPage() {
     },
     [previewAgreementId, navigate]
   );
-  const [previewModuleSheet] = useLocalStorage(
-    incompletePrimaryModuleSheetPreviewFeatureFlag.id,
-    incompletePrimaryModuleSheetPreviewFeatureFlag.default_value
+  const [isPreviewModuleSheetFeatureEnabled] = useLocalStorage(
+    experimentalPrimaryModuleSheetPreviewFeatureFlag.id,
+    experimentalPrimaryModuleSheetPreviewFeatureFlag.default_value
   );
 
   const [_trackTableLoading, _setTrackTableLoading] = useState(false);
@@ -162,7 +162,7 @@ function AgreementsSearchPage() {
                 const agreementId = item.table.getRow(item.row.id).original
                   .AgreementId;
 
-                return previewModuleSheet ? (
+                return isPreviewModuleSheetFeatureEnabled ? (
                   <span className="flex items-center justify-start gap-x-4">
                     <Link
                       to="/agreements/$agreementId"
@@ -223,7 +223,12 @@ function AgreementsSearchPage() {
             enableHiding: column.columnHeader !== "AgreementNumber",
           })
         ),
-    [columnsData.data.body, columnsData.data.status, previewModuleSheet, t]
+    [
+      columnsData.data.body,
+      columnsData.data.status,
+      isPreviewModuleSheetFeatureEnabled,
+      t,
+    ]
   );
 
   const saveColumnsMutation = useMutation({
@@ -283,7 +288,7 @@ function AgreementsSearchPage() {
   return (
     <>
       <React.Suspense fallback={null}>
-        {previewModuleSheet ? (
+        {isPreviewModuleSheetFeatureEnabled ? (
           <PreviewAgreementSheet
             agreementId={previewAgreementId}
             open={!!previewAgreementId}

--- a/src/routes/_auth/agreements/index.route.tsx
+++ b/src/routes/_auth/agreements/index.route.tsx
@@ -6,7 +6,6 @@ import { getAuthFromRouterContext } from "@/utils/auth";
 import { STORAGE_DEFAULTS } from "@/utils/constants";
 import { normalizeAgreementListSearchParams } from "@/utils/normalize-search-params";
 import {
-  fetchAgreementByIdOptions,
   fetchAgreementsSearchColumnsOptions,
   fetchAgreementsSearchListOptions,
 } from "@/utils/query/agreement";
@@ -26,10 +25,6 @@ export const Route = createFileRoute("/_auth/agreements/")({
     const auth = getAuthFromRouterContext(context);
     const parsedSearch = normalizeAgreementListSearchParams(search);
 
-    const previewViewAgreementByIdOptions = search?.agreement_id
-      ? fetchAgreementByIdOptions({ auth, agreementId: search?.agreement_id })
-      : null;
-
     return {
       authParams: auth,
       searchColumnsOptions: fetchAgreementsSearchColumnsOptions({
@@ -47,7 +42,6 @@ export const Route = createFileRoute("/_auth/agreements/")({
         },
       }),
       search: parsedSearch,
-      previewAgreementIdOptions: previewViewAgreementByIdOptions,
     };
   },
   loaderDeps: ({ search }) => ({
@@ -57,12 +51,7 @@ export const Route = createFileRoute("/_auth/agreements/")({
     agreement_id: search?.agreement_id ?? "",
   }),
   loader: async ({ context }) => {
-    const {
-      queryClient,
-      searchColumnsOptions,
-      searchListOptions,
-      previewAgreementIdOptions,
-    } = context;
+    const { queryClient, searchColumnsOptions, searchListOptions } = context;
 
     const promises = [];
 
@@ -71,11 +60,6 @@ export const Route = createFileRoute("/_auth/agreements/")({
 
     // get list
     promises.push(queryClient.ensureQueryData(searchListOptions));
-
-    // get preview agreement
-    if (previewAgreementIdOptions) {
-      promises.push(queryClient.ensureQueryData(previewAgreementIdOptions));
-    }
 
     await Promise.all(promises);
     return;

--- a/src/routes/_auth/agreements/index.route.tsx
+++ b/src/routes/_auth/agreements/index.route.tsx
@@ -54,6 +54,7 @@ export const Route = createFileRoute("/_auth/agreements/")({
     page: search.page,
     size: search.size,
     filters: sortObjectKeys(search.filters),
+    agreement_id: search?.agreement_id ?? "",
   }),
   loader: async ({ context }) => {
     const {

--- a/src/schemas/agreement/searchFilters.ts
+++ b/src/schemas/agreement/searchFilters.ts
@@ -46,5 +46,6 @@ export const AgreementSearchQuerySchema = z.object({
   page: z.coerce.number().min(1).default(1).optional(),
   size: z.coerce.number().min(1).default(10).optional(),
   filters: AgreementFiltersSchema.optional(),
+  agreement_id: z.coerce.string().optional(),
 });
 export type TAgreementSearchQuery = z.infer<typeof AgreementSearchQuerySchema>;

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -37,6 +37,14 @@ const dashboardLayoutFeatureFlag: DropdownFeatureFlag = {
   default_value: "v1",
   options: ["v1", "v2"],
 } as const;
+const incompletePrimaryModuleSheetPreviewFeatureFlag: SwitchFeatureFlag = {
+  id: "incomplete_primaryModule.sheet.preview",
+  name: "Primary module sheet preview",
+  description:
+    "Toggle this feature to view a preview of the pages in the primary modules (e.g. Customers, Fleet, Reservations, and Agreements) when clicking their links on the search pages.",
+  input_type: "switch",
+  default_value: false,
+} as const;
 const incompleteSettingsNavigationFeatureFlag: SwitchFeatureFlag = {
   id: "incomplete_all.settings.navigation",
   name: "Incomplete settings navigation",
@@ -77,4 +85,5 @@ export {
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
   incompleteLocationsApplicationSettingsTabFeatureFlag,
+  incompletePrimaryModuleSheetPreviewFeatureFlag,
 };

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -74,6 +74,7 @@ const incompleteLocationsApplicationSettingsTabFeatureFlag: SwitchFeatureFlag =
 
 const featureFlags: FeatureFlags = [
   dashboardLayoutFeatureFlag,
+  incompletePrimaryModuleSheetPreviewFeatureFlag,
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
   incompleteLocationsApplicationSettingsTabFeatureFlag,

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -37,8 +37,8 @@ const dashboardLayoutFeatureFlag: DropdownFeatureFlag = {
   default_value: "v1",
   options: ["v1", "v2"],
 } as const;
-const incompletePrimaryModuleSheetPreviewFeatureFlag: SwitchFeatureFlag = {
-  id: "incomplete_primaryModule.sheet.preview",
+const experimentalPrimaryModuleSheetPreviewFeatureFlag: SwitchFeatureFlag = {
+  id: "experimental_primaryModule.sheet.preview",
   name: "Primary module sheet preview",
   description:
     "Toggle this feature to view a preview of the pages in the primary modules (e.g. Customers, Fleet, Reservations, and Agreements) when clicking their links on the search pages.",
@@ -74,7 +74,7 @@ const incompleteLocationsApplicationSettingsTabFeatureFlag: SwitchFeatureFlag =
 
 const featureFlags: FeatureFlags = [
   dashboardLayoutFeatureFlag,
-  incompletePrimaryModuleSheetPreviewFeatureFlag,
+  experimentalPrimaryModuleSheetPreviewFeatureFlag,
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
   incompleteLocationsApplicationSettingsTabFeatureFlag,
@@ -86,5 +86,5 @@ export {
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
   incompleteLocationsApplicationSettingsTabFeatureFlag,
-  incompletePrimaryModuleSheetPreviewFeatureFlag,
+  experimentalPrimaryModuleSheetPreviewFeatureFlag,
 };

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -28,7 +28,7 @@ export type FeatureFlag =
 export type FeatureFlags<TFlag = FeatureFlag> = TFlag[];
 
 // Features START
-export const dashboardLayoutFeatureFlag: DropdownFeatureFlag = {
+const dashboardLayoutFeatureFlag: DropdownFeatureFlag = {
   id: "experimental_dashboard.layout",
   name: "Dashboard layout",
   description:
@@ -37,7 +37,7 @@ export const dashboardLayoutFeatureFlag: DropdownFeatureFlag = {
   default_value: "v1",
   options: ["v1", "v2"],
 } as const;
-export const incompleteSettingsNavigationFeatureFlag: SwitchFeatureFlag = {
+const incompleteSettingsNavigationFeatureFlag: SwitchFeatureFlag = {
   id: "incomplete_all.settings.navigation",
   name: "Incomplete settings navigation",
   description:
@@ -45,7 +45,7 @@ export const incompleteSettingsNavigationFeatureFlag: SwitchFeatureFlag = {
   input_type: "switch",
   default_value: false,
 } as const;
-export const incompleteApplicationSettingsTabsFeatureFlag: SwitchFeatureFlag = {
+const incompleteApplicationSettingsTabsFeatureFlag: SwitchFeatureFlag = {
   id: "incomplete_application.settings.all",
   name: "All incomplete application settings tabs",
   description:
@@ -53,10 +53,10 @@ export const incompleteApplicationSettingsTabsFeatureFlag: SwitchFeatureFlag = {
   input_type: "switch",
   default_value: false,
 } as const;
-export const incompleteLocationsApplicationSettingsTabFeatureFlag: SwitchFeatureFlag =
+const incompleteLocationsApplicationSettingsTabFeatureFlag: SwitchFeatureFlag =
   {
     id: "incomplete_application.settings.locations",
-    name: "Incomplete locations application settings tab",
+    name: "Unfinished locations application settings tab",
     description:
       "Toggle this feature to enable the incomplete locations application settings tab, which will display a list of settings panels that are incomplete provided your account has access to them.",
     input_type: "switch",
@@ -64,9 +64,17 @@ export const incompleteLocationsApplicationSettingsTabFeatureFlag: SwitchFeature
   } as const;
 // Features END
 
-export const featureFlags: FeatureFlags = [
+const featureFlags: FeatureFlags = [
   dashboardLayoutFeatureFlag,
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
   incompleteLocationsApplicationSettingsTabFeatureFlag,
 ] as const;
+
+export {
+  featureFlags, // the array of all the feature flags
+  dashboardLayoutFeatureFlag,
+  incompleteSettingsNavigationFeatureFlag,
+  incompleteApplicationSettingsTabsFeatureFlag,
+  incompleteLocationsApplicationSettingsTabFeatureFlag,
+};


### PR DESCRIPTION
Goal:
The goal of this change is to allow the user to view some pertinent/important agreement data without having to navigate to the agreement page.
<details><summary>ui inspiration</summary>
<img src="https://github.com/SeanCassiere/nv-rental-clone/assets/33615041/3957087b-c499-4c70-a159-0882dc5e0501" alt="image" />
</details> 

Live changes:
* Add a new feature flag named `experimental_primaryModule.sheet.preview` that can be toggled using the "Experimental features" dialog.

Feature flagged changes:
* Changed the module link in the data table of the agreements page to ALSO allow opening the preview sheet if the feature flag is present. 
* Added a sheet for previewing agreement data.
* Lazy loaded all changes to only load if the feature flag has been enabled.