### PR TITLE
feat: add a new layout for the reports list page

### DIFF
--- a/src/lib/config/features.ts
+++ b/src/lib/config/features.ts
@@ -53,10 +53,19 @@ const incompleteApplicationSettingsTabsFeatureFlag: SwitchFeatureFlag = {
   input_type: "switch",
   default_value: false,
 } as const;
+const incompleteReportsListPageFeatureFlag: SwitchFeatureFlag = {
+  id: "incomplete_reports.list.page",
+  name: "Incomplete reports list page",
+  description:
+    "Toggle this feature to enable the incomplete reports list page, which will display the new layout for the reports list page.",
+  input_type: "switch",
+  default_value: false,
+} as const;
 // Features END
 
 const featureFlags: FeatureFlags = [
   dashboardLayoutFeatureFlag,
+  incompleteReportsListPageFeatureFlag,
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
 ] as const;
@@ -64,6 +73,7 @@ const featureFlags: FeatureFlags = [
 export {
   featureFlags, // the array of all the feature flags
   dashboardLayoutFeatureFlag,
+  incompleteReportsListPageFeatureFlag,
   incompleteSettingsNavigationFeatureFlag,
   incompleteApplicationSettingsTabsFeatureFlag,
 };

--- a/src/routes/_auth/reports/-components/reports-list-v1.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v1.tsx
@@ -19,8 +19,6 @@ function tenantReportFilterFn(report: TReportsListItem) {
   return !tenantReports.includes(report.reportId);
 }
 
-const allSearchCategory = "all";
-
 interface ReportsListV1Props {
   currentCategory: string;
   internationalization: {
@@ -56,7 +54,7 @@ export default function ReportsListV1(props: ReportsListV1Props) {
     {} as Record<string, TReportsListItem[]>
   );
 
-  const chips = [allSearchCategory, ...Object.keys(grouped)];
+  const chips = [i18_all, ...Object.keys(grouped)];
 
   return (
     <section className="mx-auto mt-4 flex max-w-full flex-col gap-5 px-2 pt-1.5 sm:mx-4 sm:px-1">
@@ -67,7 +65,7 @@ export default function ReportsListV1(props: ReportsListV1Props) {
             to: "/reports",
             search: (prev) => ({
               ...prev,
-              category: value === allSearchCategory ? undefined : value,
+              category: value === i18_all ? undefined : value,
             }),
           });
         }}
@@ -75,7 +73,7 @@ export default function ReportsListV1(props: ReportsListV1Props) {
         <TabsList className="mb-4 w-full sm:max-w-max">
           {chips.map((chip, idx) => (
             <TabsTrigger key={`tab-trigger-${idx}`} value={chip}>
-              {chip === allSearchCategory ? i18_all : chip}
+              {chip === i18_all ? i18_all : chip}
             </TabsTrigger>
           ))}
         </TabsList>
@@ -84,7 +82,7 @@ export default function ReportsListV1(props: ReportsListV1Props) {
             <div className="mb-6 flex flex-col gap-5">
               {[...Object.entries(grouped)]
                 .filter(([category]) =>
-                  currentCategory !== allSearchCategory
+                  currentCategory !== i18_all
                     ? category.includes(currentCategory)
                     : true
                 )

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -135,7 +135,7 @@ export default function ReportsListV2(props: ReportsListV2Props) {
           value={currentCategory || internationalization.all}
           onValueChange={onValueChange}
         >
-          <SelectTrigger className="w-full truncate whitespace-nowrap sm:h-8 sm:w-[220px]">
+          <SelectTrigger className="w-full truncate whitespace-nowrap sm:w-[220px]">
             <SelectValue placeholder="Select a category" className="truncate" />
           </SelectTrigger>
           <SelectContent>
@@ -155,17 +155,16 @@ export default function ReportsListV2(props: ReportsListV2Props) {
         <ul
           className={cn(
             "-mx-px grid grid-cols-1 overflow-hidden rounded border-l border-border sm:mx-0 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-            reports.length > 2 ? "border-t" : ""
+            reports.length > 2
+              ? "border-t"
+              : "[&>li:nth-child(1)]:border-t [&>li]:sm:border-t"
           )}
         >
           {reports.length > 0 ? (
             reports.map((report, idx) => (
               <li
                 key={`report_item_${report.id}_${idx}`}
-                className={cn(
-                  "relative flex min-h-[5rem] flex-col items-start justify-between border-b border-r border-border bg-card p-4 sm:p-6",
-                  reports.length > 2 ? "" : "border-t"
-                )}
+                className="relative flex min-h-[5rem] flex-col items-start justify-between border-b border-r border-border bg-card p-4 sm:p-6"
               >
                 <Link
                   to="/reports/$reportId"
@@ -178,7 +177,18 @@ export default function ReportsListV2(props: ReportsListV2Props) {
                   {report.title}
                 </Link>
                 <p className="text-sm text-foreground/60">
-                  {report.categories.join(", ")}
+                  {report.categories.map((category, idx) => (
+                    <React.Fragment key={`${report.id}_${category}_${idx}`}>
+                      <Link
+                        to="/reports"
+                        className="underline-offset-4 hover:text-muted-foreground hover:underline"
+                        search={(s) => ({ ...s, category })}
+                      >
+                        {category}
+                      </Link>
+                      {idx < report.categories.length - 1 && ", "}
+                    </React.Fragment>
+                  ))}
                 </p>
               </li>
             ))

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -1,10 +1,115 @@
 import React from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getRouteApi, Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+
+import { EmptyState } from "@/components/layouts/empty-state";
+import { icons } from "@/components/ui/icons";
+
+import type { TReportsListItem } from "@/lib/schemas/report";
+
+const PAYMENT_BREAKDOWN_REPORT_ID = "117";
+const BUSINESS_SUMMARY_REPORT_ID = "116";
+const DAILY_BUSINESS_REPORT_ID = "195";
+
+function tenantReportFilterFn(report: TReportsListItem) {
+  const tenantReports = [
+    PAYMENT_BREAKDOWN_REPORT_ID,
+    BUSINESS_SUMMARY_REPORT_ID,
+    DAILY_BUSINESS_REPORT_ID,
+  ];
+  return !tenantReports.includes(report.reportId);
+}
+
+type TransformedReportItem = {
+  id: string;
+  title: TReportsListItem["title"];
+  categories: string[];
+  internal_name: TReportsListItem["name"];
+};
+function transformReportsList(
+  list: TReportsListItem[]
+): TransformedReportItem[] {
+  return list.reduce((acc, report) => {
+    const existing = acc.find((item) => item.id === report.reportId);
+
+    if (existing) {
+      if (
+        !existing.categories.includes(report.reportCategory ?? "Uncategorized")
+      ) {
+        existing.categories.push(report.reportCategory ?? "Uncategorized");
+      }
+    } else {
+      acc.push({
+        id: report.reportId,
+        title: report.title,
+        categories: [report.reportCategory ?? "Uncategorized"],
+        internal_name: report.name,
+      });
+    }
+
+    return acc;
+  }, [] as TransformedReportItem[]);
+}
+
+const routeApi = getRouteApi("/_auth/reports/");
 
 export default function ReportsListV2() {
+  const { t } = useTranslation();
+
+  const { searchListOptions } = routeApi.useRouteContext();
+  const query = useSuspenseQuery(searchListOptions);
+
+  const reportsList = React.useMemo(
+    () => (query.data?.status === 200 ? query.data.body : []),
+    [query.data?.status, query.data?.body]
+  );
+  const tenantFiltered = React.useMemo(
+    () => reportsList.filter(tenantReportFilterFn),
+    [reportsList]
+  );
+  const reports = React.useMemo(
+    () => transformReportsList(tenantFiltered),
+    [tenantFiltered]
+  );
+
   return (
-    <section className="mx-auto max-w-full px-2 pt-1.5 sm:mx-4 sm:px-1">
-      <h4>Reports List V2</h4>
-      <p>Coming soon...</p>
+    <section className="mx-auto my-4 max-w-full px-2 pt-1.5 sm:mx-4 sm:px-1">
+      {/* <h4>Reports List V2</h4> */}
+      <nav>
+        <ul className="-mx-px grid grid-cols-2 overflow-hidden rounded border-l border-t border-border sm:mx-0 md:grid-cols-2 xl:grid-cols-3">
+          {reports.length > 0 ? (
+            reports.map((report, idx) => (
+              <li
+                key={`report_item_${report.id}_${idx}`}
+                className="group relative flex min-h-[5rem] flex-col items-start justify-between border-b border-r border-border bg-card p-4 sm:p-6"
+              >
+                <Link
+                  to="/reports/$reportId"
+                  params={{ reportId: report.id }}
+                  className="w-full text-balance py-2 sm:px-6"
+                >
+                  {report.title}
+                </Link>
+                <p className="text-sm text-foreground/60 sm:px-6">
+                  {report.categories.join(", ")}
+                </p>
+              </li>
+            ))
+          ) : (
+            <li className="col-span-2 md:col-span-3 lg:col-span-4">
+              <EmptyState
+                title={t("display.noResultsFound", { ns: "labels" })}
+                subtitle={t("noResultsWereFoundForThisSearch", {
+                  ns: "messages",
+                })}
+                icon={icons.FolderEmpty}
+                styles={{ containerClassName: "border-t-0" }}
+              />
+            </li>
+          )}
+        </ul>
+      </nav>
     </section>
   );
 }

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -143,7 +143,7 @@ export default function ReportsListV2(props: ReportsListV2Props) {
         >
           <SelectTrigger
             id={selectId}
-            className="w-full truncate whitespace-nowrap sm:w-[220px]"
+            className="w-full truncate whitespace-nowrap bg-card sm:w-[220px]"
           >
             <SelectValue placeholder="Select a category" className="truncate" />
           </SelectTrigger>
@@ -180,7 +180,7 @@ export default function ReportsListV2(props: ReportsListV2Props) {
                   params={{ reportId: report.id }}
                   className={cn(
                     buttonVariants({ variant: "link" }),
-                    "flex grow justify-start text-balance px-0 py-2"
+                    "flex w-full grow justify-start text-balance px-0 py-2"
                   )}
                 >
                   {report.title}

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -133,31 +133,36 @@ export default function ReportsListV2(props: ReportsListV2Props) {
 
   return (
     <section className="mx-auto mb-4 mt-2 grid max-w-full gap-2 px-2 pt-1.5 sm:mx-4 sm:px-1 md:mb-8">
-      <div className="flex items-center justify-start">
-        <Label htmlFor={selectId} className="sr-only">
-          Filter down the reports by their category
-        </Label>
-        <Select
-          value={currentCategory || internationalization.all}
-          onValueChange={onValueChange}
-        >
-          <SelectTrigger
-            id={selectId}
-            className="w-full truncate whitespace-nowrap bg-card sm:w-[220px]"
+      <div className="grid grid-cols-1 space-y-2 sm:grid-cols-2 sm:space-x-2 sm:space-y-0 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div>
+          <Label htmlFor={selectId} className="sr-only">
+            Filter down the reports by their category
+          </Label>
+          <Select
+            value={currentCategory || internationalization.all}
+            onValueChange={onValueChange}
           >
-            <SelectValue placeholder="Select a category" className="truncate" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectLabel>Categories</SelectLabel>
-              {categories.map((category) => (
-                <SelectItem key={`category_${category}`} value={category}>
-                  {category}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
+            <SelectTrigger
+              id={selectId}
+              className="w-full truncate whitespace-nowrap bg-card"
+            >
+              <SelectValue
+                placeholder="Select a category"
+                className="truncate"
+              />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Report categories</SelectLabel>
+                {categories.map((category) => (
+                  <SelectItem key={`category_${category}`} value={category}>
+                    {category}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       <nav>

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/layouts/empty-state";
 import { buttonVariants } from "@/components/ui/button";
 import { icons } from "@/components/ui/icons";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -76,6 +77,8 @@ interface ReportsListV2Props {
 export default function ReportsListV2(props: ReportsListV2Props) {
   const { currentCategory, internationalization } = props;
 
+  const selectId = React.useId();
+
   const { t } = useTranslation();
   const navigate = useNavigate({ from: "/reports" });
 
@@ -131,11 +134,17 @@ export default function ReportsListV2(props: ReportsListV2Props) {
   return (
     <section className="mx-auto mb-4 mt-2 grid max-w-full gap-2 px-2 pt-1.5 sm:mx-4 sm:px-1 md:mb-8">
       <div className="flex items-center justify-start">
+        <Label htmlFor={selectId} className="sr-only">
+          Filter down the reports by their category
+        </Label>
         <Select
           value={currentCategory || internationalization.all}
           onValueChange={onValueChange}
         >
-          <SelectTrigger className="w-full truncate whitespace-nowrap sm:w-[220px]">
+          <SelectTrigger
+            id={selectId}
+            className="w-full truncate whitespace-nowrap sm:w-[220px]"
+          >
             <SelectValue placeholder="Select a category" className="truncate" />
           </SelectTrigger>
           <SelectContent>

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -54,7 +54,15 @@ function transformReportsList(
 
 const routeApi = getRouteApi("/_auth/reports/");
 
-export default function ReportsListV2() {
+interface ReportsListV2Props {
+  currentCategory: string;
+  internationalization: {
+    all: string;
+  };
+}
+
+export default function ReportsListV2(props: ReportsListV2Props) {
+  const { currentCategory, internationalization } = props;
   const { t } = useTranslation();
 
   const { searchListOptions } = routeApi.useRouteContext();
@@ -68,16 +76,23 @@ export default function ReportsListV2() {
     () => reportsList.filter(tenantReportFilterFn),
     [reportsList]
   );
-  const reports = React.useMemo(
-    () => transformReportsList(tenantFiltered),
-    [tenantFiltered]
-  );
+  const reports = React.useMemo(() => {
+    const transformed = transformReportsList(tenantFiltered);
+
+    if (!currentCategory || currentCategory === internationalization.all) {
+      return transformed;
+    }
+
+    return transformed.filter((report) =>
+      report.categories.includes(currentCategory)
+    );
+  }, [currentCategory, internationalization.all, tenantFiltered]);
 
   return (
-    <section className="mx-auto my-4 max-w-full px-2 pt-1.5 sm:mx-4 sm:px-1">
+    <section className="mx-auto mb-4 mt-4 max-w-full px-2 pt-1.5 sm:mx-4 sm:px-1 md:mb-8">
       {/* <h4>Reports List V2</h4> */}
       <nav>
-        <ul className="-mx-px grid grid-cols-2 overflow-hidden rounded border-l border-t border-border sm:mx-0 md:grid-cols-2 xl:grid-cols-3">
+        <ul className="-mx-px grid grid-cols-2 overflow-hidden rounded border-l border-t border-border sm:mx-0 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {reports.length > 0 ? (
             reports.map((report, idx) => (
               <li

--- a/src/routes/_auth/reports/-components/reports-list-v2.tsx
+++ b/src/routes/_auth/reports/-components/reports-list-v2.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function ReportsListV2() {
+  return (
+    <section className="mx-auto max-w-full px-2 pt-1.5 sm:mx-4 sm:px-1">
+      <h4>Reports List V2</h4>
+      <p>Coming soon...</p>
+    </section>
+  );
+}

--- a/src/routes/_auth/reports/index.lazy.tsx
+++ b/src/routes/_auth/reports/index.lazy.tsx
@@ -4,8 +4,11 @@ import { createLazyRoute, getRouteApi } from "@tanstack/react-router";
 import { Separator } from "@/components/ui/separator";
 
 import { useDocumentTitle } from "@/lib/hooks/useDocumentTitle";
+import { useLocalStorage } from "@/lib/hooks/useLocalStorage";
 
 import { titleMaker } from "@/lib/utils/title-maker";
+
+import { incompleteReportsListPageFeatureFlag } from "@/lib/config/features";
 
 import { cn } from "@/lib/utils";
 
@@ -14,6 +17,7 @@ export const Route = createLazyRoute("/_auth/reports/")({
 });
 
 const ReportsListV1 = React.lazy(() => import("./-components/reports-list-v1"));
+const ReportsListV2 = React.lazy(() => import("./-components/reports-list-v2"));
 
 const routeApi = getRouteApi("/_auth/reports/");
 
@@ -22,6 +26,11 @@ function ReportSearchPage() {
   const ALL_KEY = "All";
 
   const { category = "all" } = routeApi.useSearch();
+
+  const [showNewLayout] = useLocalStorage(
+    incompleteReportsListPageFeatureFlag.id,
+    incompleteReportsListPageFeatureFlag.default_value
+  );
 
   useDocumentTitle(titleMaker("Reports"));
 
@@ -41,10 +50,14 @@ function ReportSearchPage() {
         <Separator className="mt-3.5" />
       </section>
 
-      <ReportsListV1
-        currentCategory={category}
-        internationalization={{ all: ALL_KEY }}
-      />
+      {showNewLayout ? (
+        <ReportsListV2 />
+      ) : (
+        <ReportsListV1
+          currentCategory={category}
+          internationalization={{ all: ALL_KEY }}
+        />
+      )}
     </>
   );
 }

--- a/src/routes/_auth/reports/index.lazy.tsx
+++ b/src/routes/_auth/reports/index.lazy.tsx
@@ -25,7 +25,7 @@ function ReportSearchPage() {
   // TODO: Replace with a value from the useTranslation() hook
   const ALL_KEY = "All";
 
-  const { category = "all" } = routeApi.useSearch();
+  const { category = ALL_KEY } = routeApi.useSearch();
 
   const [showNewLayout] = useLocalStorage(
     incompleteReportsListPageFeatureFlag.id,
@@ -51,7 +51,10 @@ function ReportSearchPage() {
       </section>
 
       {showNewLayout ? (
-        <ReportsListV2 />
+        <ReportsListV2
+          currentCategory={category}
+          internationalization={{ all: ALL_KEY }}
+        />
       ) : (
         <ReportsListV1
           currentCategory={category}

--- a/src/routes/_auth/reports/index.lazy.tsx
+++ b/src/routes/_auth/reports/index.lazy.tsx
@@ -47,7 +47,7 @@ function ReportSearchPage() {
         <p className={cn("text-base text-foreground/80")}>
           Select and run a report from the list available to you.
         </p>
-        <Separator className="mt-3.5" />
+        {!showNewLayout ? <Separator className="mt-3.5" /> : null}
       </section>
 
       {showNewLayout ? (

--- a/src/routes/_auth/reports/index.tsx
+++ b/src/routes/_auth/reports/index.tsx
@@ -29,4 +29,5 @@ export const Route = createFileRoute("/_auth/reports/")({
 
     return;
   },
+  loaderDeps: ({ search: { category } }) => ({ category }),
 });


### PR DESCRIPTION
Goal:
The goal of this change is to introduce a new layout to the reports list page (`/reports`), moving it away from the current barebones user interface.

<details><summary>Old</summary>
<p>
<img src="https://github.com/SeanCassiere/nv-rental-clone/assets/33615041/cfdbdcb5-e310-41f4-8f80-64d66f892b2f" alt="Screenshot 2024-02-22 at 23 56 26">
</p>
</details> 

<details><summary>New</summary>
<p>
<img src="https://github.com/SeanCassiere/nv-rental-clone/assets/33615041/838063a5-1db2-4d9e-9345-497cddc81b6c" alt="Screenshot 2024-02-22 at 23 56 45">
</p>
</details>

Live changes:
* Add a new feature flag named `incomplete_reports.list.page` that can be toggled using the "Experimental features" dialog.
* Display the right correct component based on the `incomplete_reports.list.page` flag.

Feature flagged changes:
* Implement the new UI for the reports list page.