### PR TITLE
feat: use the `recharts@alpha` releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.13",
-    "@tanstack/router-vite-plugin": "^1.34.8",
+    "@tanstack/router-vite-plugin": "^1.35.4",
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "^7.51.5",
     "react-i18next": "^14.1.2",
     "react-oidc-context": "^3.1.0",
-    "recharts": "^2.12.7",
+    "recharts": "2.13.0-alpha.4",
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ dependencies:
     specifier: ^3.1.0
     version: 3.1.0(oidc-client-ts@3.0.1)(react@18.3.1)
   recharts:
-    specifier: ^2.12.7
-    version: 2.12.7(react-dom@18.3.1)(react@18.3.1)
+    specifier: 2.13.0-alpha.4
+    version: 2.13.0-alpha.4(react-dom@18.3.1)(react@18.3.1)
   sonner:
     specifier: ^1.4.41
     version: 1.4.41(react-dom@18.3.1)(react@18.3.1)
@@ -4639,6 +4639,10 @@ packages:
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+    dev: false
+
   /react-oidc-context@3.1.0(oidc-client-ts@3.0.1)(react@18.3.1):
     resolution: {integrity: sha512-ceQztvDfdl28mbr0So31XF/tCJamyF1+nm4AQNIE/nub+Xs9PLtDqLy/+75Yx1ahI0/n3nsq0R2qcP0R2Laa3Q==}
     engines: {node: '>=18'}
@@ -4760,8 +4764,8 @@ packages:
       decimal.js-light: 2.5.1
     dev: false
 
-  /recharts@2.12.7(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==}
+  /recharts@2.13.0-alpha.4(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-K9naL6F7pEcDYJE6yFQASSCQecSLPP0JagnvQ9hPtA/aHgsxsnIOjouLP5yrFZehxzfCkV5TEORr7/uNtSr7Qw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -4772,7 +4776,7 @@ packages:
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-is: 16.13.1
+      react-is: 18.3.1
       react-smooth: 4.0.1(react-dom@18.3.1)(react@18.3.1)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ devDependencies:
     specifier: ^0.5.13
     version: 0.5.13(tailwindcss@3.4.4)
   '@tanstack/router-vite-plugin':
-    specifier: ^1.34.8
-    version: 1.34.8(vite@5.2.12)
+    specifier: ^1.35.4
+    version: 1.35.4(vite@5.2.12)
   '@types/node':
     specifier: ^20.14.2
     version: 20.14.2
@@ -2266,16 +2266,16 @@ packages:
       - csstype
     dev: false
 
-  /@tanstack/router-generator@1.34.8:
-    resolution: {integrity: sha512-xi0otLis4zQ8lYVgvNfUTDHKnboL2swXpHcLiG+bKYDihPnw4r3qRO0ULGsqV1n/w6yZAaQ2tZwvZ7Zf0G2pPg==}
+  /@tanstack/router-generator@1.35.4:
+    resolution: {integrity: sha512-muV4qNnh7RjGakPV+ERaJwY6Jz1ERDWuGBV9iIkw3UV+Dx0wnxyXAnNDSTX9E38WJmNL48uesXJ0jpV/8Irx9Q==}
     engines: {node: '>=12'}
     dependencies:
       prettier: 3.3.1
       zod: 3.23.8
     dev: true
 
-  /@tanstack/router-vite-plugin@1.34.8(vite@5.2.12):
-    resolution: {integrity: sha512-FZRl7GVda/1NMEbnalXhYI2e9Qe8MduxXRNZ2cJMYgPR/FxMiao+XQAN+mTD4OoMxJ8gKY+IshgRxCc3xwu6bA==}
+  /@tanstack/router-vite-plugin@1.35.4(vite@5.2.12):
+    resolution: {integrity: sha512-uGr6m9giWMU9nDZ7krR9hjWpaOi/M4/RBTgI6UrgBoPvSmXc66R319vb4iY57jyN8gZlxsajvxLEf/hVJy+NsQ==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/core': 7.24.6
@@ -2287,7 +2287,7 @@ packages:
       '@babel/template': 7.24.6
       '@babel/traverse': 7.24.6
       '@babel/types': 7.24.6
-      '@tanstack/router-generator': 1.34.8
+      '@tanstack/router-generator': 1.35.4
       '@types/babel__core': 7.20.5
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4


### PR DESCRIPTION
* Set recharts to the `alpha` tag instead of `latest`.
* Bumps the version of the TanStack Router Vite Plugin.